### PR TITLE
Add sync script requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,3 +357,6 @@ components:
 security:
 - BearerAuth: []
 ```
+
+## Updating the API spec
+Run `pip install -r requirements.txt` and then `python scripts/sync_spec.py` to regenerate the OpenAPI files and the README snippet.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+beautifulsoup4
+pyyaml


### PR DESCRIPTION
## Summary
- document how to regenerate the OpenAPI spec
- add Python requirements for the sync script

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858b0ca70c08327b4df5ff2ab702847