### PR TITLE
Update Notion OpenAPI spec and sync script

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -14,123 +14,389 @@
   "paths": {
     "/v1/blocks/{block_id}": {
       "delete": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "patch": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/blocks/{block_id}/children": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "patch": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/comments": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       },
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/databases": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/databases/{database_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "database_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "patch": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "database_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/databases/{database_id}/query": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "database_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/file_uploads": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       },
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/file_uploads/{file_upload_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "file_upload_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/file_uploads/{file_upload_id}/complete": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "file_upload_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/file_uploads/{file_upload_id}/send": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "file_upload_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/oauth/introspect": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/oauth/revoke": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/oauth/token": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/pages": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/pages/{page_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "patch": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/pages/{page_id}/properties/{property_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "property_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/v1/search": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/users": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/users/me": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        }
       }
     },
     "/v1/users/{user_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     }
   },

--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -9,78 +9,227 @@ servers:
 paths:
   /v1/blocks/{block_id}:
     delete:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
     patch:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/blocks/{block_id}/children:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
     patch:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/comments:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/databases:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/databases/{database_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: database_id
+        in: path
+        required: true
+        schema:
+          type: string
     patch:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: database_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/databases/{database_id}/query:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: database_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/file_uploads:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/file_uploads/{file_upload_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: file_upload_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/file_uploads/{file_upload_id}/complete:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: file_upload_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/file_uploads/{file_upload_id}/send:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: file_upload_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/oauth/introspect:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/oauth/revoke:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/oauth/token:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/pages:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/pages/{page_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: page_id
+        in: path
+        required: true
+        schema:
+          type: string
     patch:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: page_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/pages/{page_id}/properties/{property_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: page_id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: property_id
+        in: path
+        required: true
+        schema:
+          type: string
   /v1/search:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/users:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/users/me:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
   /v1/users/{user_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
 components:
   headers:
     NotionVersion:

--- a/scripts/sync_spec.py
+++ b/scripts/sync_spec.py
@@ -39,7 +39,12 @@ def main():
 
     new_paths = {}
     for method, path in sorted(new_endpoints, key=lambda x: (x[1], x[0])):
-        op = old_paths.get(path, {}).get(method.lower(), {"responses": {}})
+        op = old_paths.get(path, {}).get(
+            method.lower(),
+            {"responses": {"default": {"description": "Default response"}}},
+        )
+        if not op.get("responses"):
+            op["responses"] = {"default": {"description": "Default response"}}
         new_paths.setdefault(path, {})[method.lower()] = op
 
     spec['paths'] = new_paths


### PR DESCRIPTION
## Summary
- regenerate OpenAPI spec with 27 endpoints
- add default responses and path parameters for validity
- sync YAML and JSON specs
- enhance sync script to ensure default responses exist

## Testing
- `openapi-spec-validator public/notion-openapi.json`
- `openapi-spec-validator public/notion-openapi.yaml`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c9437c2c8327921241d01afbdc9a