### PR TITLE
Add operationIds to Notion spec

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -14,123 +14,416 @@
   "paths": {
     "/v1/blocks/{block_id}": {
       "delete": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "deleteBlock"
       },
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "retrieveBlock"
       },
       "patch": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "updateBlock"
       }
     },
     "/v1/blocks/{block_id}/children": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "listBlockChildren"
       },
       "patch": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "appendBlockChildren"
       }
     },
     "/v1/comments": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "listComments"
       },
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "createComment"
       }
     },
     "/v1/databases": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "createDatabase"
       }
     },
     "/v1/databases/{database_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "database_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "retrieveDatabase"
       },
       "patch": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "database_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "updateDatabase"
       }
     },
     "/v1/databases/{database_id}/query": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "database_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "queryDatabase"
       }
     },
     "/v1/file_uploads": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "listFileUploads"
       },
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "createFileUpload"
       }
     },
     "/v1/file_uploads/{file_upload_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "file_upload_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "getFileUpload"
       }
     },
     "/v1/file_uploads/{file_upload_id}/complete": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "file_upload_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "completeFileUpload"
       }
     },
     "/v1/file_uploads/{file_upload_id}/send": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "file_upload_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "sendFileUpload"
       }
     },
     "/v1/oauth/introspect": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "oauthIntrospect"
       }
     },
     "/v1/oauth/revoke": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "oauthRevoke"
       }
     },
     "/v1/oauth/token": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "oauthToken"
       }
     },
     "/v1/pages": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "createPage"
       }
     },
     "/v1/pages/{page_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "retrievePage"
       },
       "patch": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "updatePage"
       }
     },
     "/v1/pages/{page_id}/properties/{property_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "property_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "getPageProperty"
       }
     },
     "/v1/search": {
       "post": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "search"
       }
     },
     "/v1/users": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "listUsers"
       }
     },
     "/v1/users/me": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "operationId": "getSelf"
       }
     },
     "/v1/users/{user_id}": {
       "get": {
-        "responses": {}
+        "responses": {
+          "default": {
+            "description": "Default response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "getUser"
       }
     }
   },

--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -9,78 +9,254 @@ servers:
 paths:
   /v1/blocks/{block_id}:
     delete:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: deleteBlock
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: retrieveBlock
     patch:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: updateBlock
   /v1/blocks/{block_id}/children:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: listBlockChildren
     patch:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: block_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: appendBlockChildren
   /v1/comments:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: listComments
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: createComment
   /v1/databases:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: createDatabase
   /v1/databases/{database_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: database_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: retrieveDatabase
     patch:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: database_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: updateDatabase
   /v1/databases/{database_id}/query:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: database_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: queryDatabase
   /v1/file_uploads:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: listFileUploads
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: createFileUpload
   /v1/file_uploads/{file_upload_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: file_upload_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: getFileUpload
   /v1/file_uploads/{file_upload_id}/complete:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: file_upload_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: completeFileUpload
   /v1/file_uploads/{file_upload_id}/send:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: file_upload_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: sendFileUpload
   /v1/oauth/introspect:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: oauthIntrospect
   /v1/oauth/revoke:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: oauthRevoke
   /v1/oauth/token:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: oauthToken
   /v1/pages:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: createPage
   /v1/pages/{page_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: page_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: retrievePage
     patch:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: page_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: updatePage
   /v1/pages/{page_id}/properties/{property_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: page_id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: property_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: getPageProperty
   /v1/search:
     post:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: search
   /v1/users:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: listUsers
   /v1/users/me:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      operationId: getSelf
   /v1/users/{user_id}:
     get:
-      responses: {}
+      responses:
+        default:
+          description: Default response
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+      operationId: getUser
 components:
   headers:
     NotionVersion:

--- a/scripts/sync_spec.py
+++ b/scripts/sync_spec.py
@@ -39,7 +39,12 @@ def main():
 
     new_paths = {}
     for method, path in sorted(new_endpoints, key=lambda x: (x[1], x[0])):
-        op = old_paths.get(path, {}).get(method.lower(), {"responses": {}})
+        op = old_paths.get(path, {}).get(
+            method.lower(),
+            {"responses": {"default": {"description": "Default response"}}},
+        )
+        if not op.get("responses"):
+            op["responses"] = {"default": {"description": "Default response"}}
         new_paths.setdefault(path, {})[method.lower()] = op
 
     spec['paths'] = new_paths


### PR DESCRIPTION
## Summary
- add `operationId` fields for all endpoints in YAML and JSON specs

## Testing
- `openapi-spec-validator public/notion-openapi.yaml`
- `openapi-spec-validator public/notion-openapi.json`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858c9437c2c8327921241d01afbdc9a