### PR TITLE
Fix missing operationId for comments

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -121,6 +121,7 @@
             "description": "Default response"
           }
         },
+        "operationId": "createComment"
       }
     },
     "/v1/databases": {


### PR DESCRIPTION
## Summary
- fix JSON spec formatting and add `createComment` operationId for `/v1/comments` POST

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858df5086688327905bd4a440e13c4b