### PR TITLE
Refine database create schema in OpenAPI

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -972,20 +972,43 @@
               }
             }
           },
-          "title": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          },
-          "icon": {
-            "$ref": "#/components/schemas/IconObject"
-          },
-          "properties": {
+        "title": {
+          "type": "array",
+          "items": {
             "type": "object",
-            "additionalProperties": true
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text"
+                ]
+              },
+              "text": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "required": [
+              "type",
+              "text"
+            ]
           }
+        },
+        "icon": {
+          "$ref": "#/components/schemas/IconObject"
+        },
+        "cover": {
+          "$ref": "#/components/schemas/FileExternal"
+        },
+        "properties": {
+          "type": "object",
+          "description": "Map of property names to property definitions. The object must include at least one property of type `title` (for example a `Name` property). Only a subset of property types are allowed when creating a database. Unsupported types, such as `status`, may be added later using the update database endpoint.",
+          "additionalProperties": true
+        }
         }
       },
       "IconObject": {

--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -626,11 +626,31 @@ components:
           type: array
           items:
             type: object
-            additionalProperties: true
+            properties:
+              type:
+                type: string
+                enum:
+                  - text
+              text:
+                type: object
+                properties:
+                  content:
+                    type: string
+            required:
+              - type
+              - text
         icon:
           $ref: '#/components/schemas/IconObject'
+        cover:
+          $ref: '#/components/schemas/FileExternal'
         properties:
           type: object
+          description: |
+            Map of property names to property definitions. The object must
+            include at least one property of type `title` (for example a
+            `Name` property). Only a subset of property types are allowed
+            when creating a database. Unsupported types, such as `status`,
+            may be added later using the update database endpoint.
           additionalProperties: true
     IconObject:
       oneOf:


### PR DESCRIPTION
## Summary
- clarify database creation schema in `public/notion-openapi.*`
  - add rich text structure for `title`
  - document limitations for `properties`
  - support `cover` field

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68590a2014f08327b33214cccd36f2fd