### PR TITLE
Add example for Notion database creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,33 @@ https://github.com/user-attachments/assets/3713f886-cd77-49c5-b223-89a4942a4068
 4. Head over to Notion Integrations and copy over your API-Key
 5. Ensure this key has access to the workspace pages & databases you'd like to reference / update
 
+## Creating a Database
+When using `POST /v1/databases` you must include a `properties` object. At least one property needs a `title` type. Here's a minimal example:
+
+```json
+{
+  "parent": { "type": "page_id", "page_id": "YOUR_PAGE_ID" },
+  "title": [{ "type": "text", "text": { "content": "Activity Logs" } }],
+  "icon": { "type": "emoji", "emoji": "🪵" },
+  "properties": {
+    "Log": { "title": {} }
+  }
+}
+```
+
+Add additional fields later with `PATCH /v1/databases/{database_id}`:
+
+```json
+{
+  "properties": {
+    "Prompt": { "rich_text": {} },
+    "Action": { "select": {} },
+    "Timestamp": { "date": {} },
+    "HTTP Status": { "number": {} }
+  }
+}
+```
+
 ## Raw Notion OpenAPI spec
 Alternatively, you could copy this raw YAML (~300 lines)
 ```yaml

--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -249,14 +249,24 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DatabaseCreate"
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseCreate"
+                },
+                "example": {
+                  "parent": { "type": "page_id", "page_id": "YOUR_PAGE_ID" },
+                  "title": [
+                    { "type": "text", "text": { "content": "Activity Logs" } }
+                  ],
+                  "icon": { "type": "emoji", "emoji": "🪵" },
+                  "properties": {
+                    "Log": { "title": {} }
+                  }
+                }
               }
             }
           }
         }
-      }
     },
     "/v1/databases/{database_id}": {
       "get": {
@@ -313,7 +323,25 @@
             }
           }
         ],
-        "operationId": "updateDatabase"
+        "operationId": "updateDatabase",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatabaseUpdate"
+              },
+              "example": {
+                "properties": {
+                  "Prompt": { "rich_text": {} },
+                  "Action": { "select": {} },
+                  "Timestamp": { "date": {} },
+                  "HTTP Status": { "number": {} }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/databases/{database_id}/query": {
@@ -1009,6 +1037,47 @@
           "description": "Map of property names to property definitions. The object must include at least one property of type `title` (for example a `Name` property). Only a subset of property types are allowed when creating a database. Unsupported types, such as `status`, may be added later using the update database endpoint.",
           "additionalProperties": true
         }
+        }
+      },
+      "DatabaseUpdate": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "text"
+                  ]
+                },
+                "text": {
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "text"
+              ]
+            }
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "icon": {
+            "$ref": "#/components/schemas/IconObject"
+          },
+          "cover": {
+            "$ref": "#/components/schemas/FileExternal"
+          }
         }
       },
       "IconObject": {

--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -163,6 +163,20 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/DatabaseCreate'
+            example:
+              parent:
+                type: page_id
+                page_id: YOUR_PAGE_ID
+              title:
+                - type: text
+                  text:
+                    content: Activity Logs
+              icon:
+                type: emoji
+                emoji: "🪵"
+              properties:
+                Log:
+                  title: {}
   /v1/databases/{database_id}:
     get:
       responses:
@@ -200,6 +214,22 @@ paths:
         schema:
           type: string
       operationId: updateDatabase
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DatabaseUpdate'
+            example:
+              properties:
+                Prompt:
+                  rich_text: {}
+                Action:
+                  select: {}
+                Timestamp:
+                  date: {}
+                HTTP Status:
+                  number: {}
   /v1/databases/{database_id}/query:
     post:
       responses:
@@ -652,6 +682,33 @@ components:
             when creating a database. Unsupported types, such as `status`,
             may be added later using the update database endpoint.
           additionalProperties: true
+    DatabaseUpdate:
+      type: object
+      properties:
+        title:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - text
+              text:
+                type: object
+                properties:
+                  content:
+                    type: string
+            required:
+              - type
+              - text
+        properties:
+          type: object
+          additionalProperties: true
+        icon:
+          $ref: '#/components/schemas/IconObject'
+        cover:
+          $ref: '#/components/schemas/FileExternal'
     IconObject:
       oneOf:
         - type: object


### PR DESCRIPTION
## Summary
- document how to create and update a database
- provide create database example in OpenAPI spec
- include DatabaseUpdate schema and patch request body examples

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68590e83712c8327bbe26befb62fc3a3