### PR TITLE
Fix DatabasePropertyCreate schema

### DIFF
--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -731,7 +731,6 @@ components:
               type: string
               format: uri
     DatabasePropertyCreate:
-      type: object
       description: Allowed property definition when creating a database
       oneOf:
         - required:


### PR DESCRIPTION
## Summary
- remove `type: object` from `DatabasePropertyCreate` schema to satisfy OpenAPI validation

## Testing
- `npm run lint`
- `npx @redocly/openapi-cli validate public/notion-openapi.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68592333b0ec8327a8d7014fdef3a44d