### PR TITLE
Fix DatabasePropertyCreate schema

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -1135,7 +1135,6 @@
         }
       },
       "DatabasePropertyCreate": {
-        "type": "object",
         "description": "Allowed property definition when creating a database",
         "oneOf": [
           {


### PR DESCRIPTION
## Summary
- remove stray `"type": "object"` line from the `DatabasePropertyCreate` schema

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859261f89148327afa8dea01eec6a0c