### PR TITLE
Update property schema for select fields

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -1177,6 +1177,15 @@
             "properties": {
               "select": {
                 "type": "object",
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                },
                 "additionalProperties": true
               }
             }
@@ -1188,6 +1197,15 @@
             "properties": {
               "multi_select": {
                 "type": "object",
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                },
                 "additionalProperties": true
               }
             }

--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -756,12 +756,24 @@ components:
           properties:
             select:
               type: object
+              properties:
+                options:
+                  type: array
+                  items:
+                    type: object
+                    additionalProperties: true
               additionalProperties: true
         - required:
             - multi_select
           properties:
             multi_select:
               type: object
+              properties:
+                options:
+                  type: array
+                  items:
+                    type: object
+                    additionalProperties: true
               additionalProperties: true
         - required:
             - date


### PR DESCRIPTION
## Summary
- allow `options` arrays in `select` and `multi_select` property definitions

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68592dde9e408327b201bf610bac1633