### PR TITLE
Fix server URL in OpenAPI spec

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://api.notion.com",
+      "url": "https://api.notion.com/v1",
       "description": "Main API server"
     }
   ],

--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: API for interacting with Notion resources such as pages and databases.
   version: 1.0.0
 servers:
-- url: https://api.notion.com
+- url: https://api.notion.com/v1
   description: Main API server
 paths:
   /v1/blocks/{block_id}:


### PR DESCRIPTION
## Summary
- ensure server URL uses `https://api.notion.com/v1`
- keep `Notion-Version` schema defaults

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68592ddfc22483278b08723c6fbdb4b0