### PR TITLE
Fix server URL in Notion OpenAPI files

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://api.notion.com/v1",
+      "url": "https://api.notion.com",
       "description": "Main API server"
     }
   ],

--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: API for interacting with Notion resources such as pages and databases.
   version: 1.0.0
 servers:
-- url: https://api.notion.com/v1
+- url: https://api.notion.com
   description: Main API server
 paths:
   /v1/blocks/{block_id}:


### PR DESCRIPTION
## Summary
- fix server url so it doesn't duplicate the version path

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68596aef1f9c8327949b87cf26dec0f3