### PR TITLE
Fix database property schema

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -1098,9 +1098,6 @@
           "properties": {
             "type": "object",
             "description": "Map of property names to property definitions. The object must\ninclude at least one property of type `title` (for example a\n`Name` property). Only a subset of property types are allowed\nwhen creating a database. Unsupported types, such as `status`,\nmay be added later using the update database endpoint.\n",
-            "properties": {
-              "Name": { "title": {} }
-            },
             "additionalProperties": {
               "$ref": "#/components/schemas/DatabasePropertyCreate"
             }


### PR DESCRIPTION
## Summary
- remove redundant `properties` block from `DatabaseCreate` schema

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68597546836883278ce4dc50de938a9f