### PR TITLE
Fix components parameters JSON

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -1025,8 +1025,8 @@
     }
   },
   "components": {
-    "parameters": [
-      {
+    "parameters": {
+      "NotionVersion": {
         "name": "Notion-Version",
         "in": "header",
         "required": true,
@@ -1036,7 +1036,7 @@
         },
         "description": "Notion API version"
       }
-    ],
+    },
     "headers": {
       "NotionVersion": {
         "required": true,


### PR DESCRIPTION
## Summary
- restore `components.parameters` in the JSON spec as an object
- run Redocly linter

## Testing
- `npx -y @redocly/cli lint public/notion-openapi.json`

------
https://chatgpt.com/codex/tasks/task_e_68598c251fc083279ed9755adefd49f1