### PR TITLE
Fix database property types in openapi example

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -317,6 +317,7 @@
                   "value": {
                     "properties": {
                       "Name": {
+                        "type": "title",
                         "title": {}
                       }
                     }
@@ -338,20 +339,28 @@
                     ],
                     "properties": {
                       "Name": {
+                        "type": "title",
                         "title": {}
                       },
                       "Action": {
+                        "type": "select",
                         "select": {
                           "options": []
                         }
                       },
                       "Endpoint": {
+                        "type": "multi_select",
                         "multi_select": {
                           "options": []
                         }
                       },
                       "Timestamp": {
+                        "type": "date",
                         "date": {}
+                      },
+                      "HTTP Status": {
+                        "type": "number",
+                        "number": {}
                       }
                     }
                   }


### PR DESCRIPTION
## Summary
- correct primitive property definitions in the `/v1/databases` example
- add missing `HTTP Status` field

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a2c14be1083278a2aa4dedaa2393f