### PR TITLE
Update DB schema and query

### DIFF
--- a/public/notion-openapi.json
+++ b/public/notion-openapi.json
@@ -311,60 +311,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseCreate"
-              },
-              "examples": {
-                "basic": {
-                  "value": {
-                    "properties": {
-                      "Name": {
-                        "type": "title",
-                        "title": {}
-                      }
-                    }
-                  }
-                },
-                "create-activity-logs": {
-                  "value": {
-                    "parent": {
-                      "type": "page_id",
-                      "page_id": "<PAGE_ID>"
-                    },
-                    "title": [
-                      {
-                        "type": "text",
-                        "text": {
-                          "content": "Activity Logs"
-                        }
-                      }
-                    ],
-                    "properties": {
-                      "Name": {
-                        "type": "title",
-                        "title": {}
-                      },
-                      "Action": {
-                        "type": "select",
-                        "select": {
-                          "options": []
-                        }
-                      },
-                      "Endpoint": {
-                        "type": "multi_select",
-                        "multi_select": {
-                          "options": []
-                        }
-                      },
-                      "Timestamp": {
-                        "type": "date",
-                        "date": {}
-                      },
-                      "HTTP Status": {
-                        "type": "number",
-                        "number": {}
-                      }
-                    }
-                  }
-                }
               }
             }
           }
@@ -383,6 +329,21 @@
           },
           "default": {
             "description": "Default response"
+          },
+          "404": {
+            "description": "Database not found or not queryable (inline?)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "object": "error",
+                  "code": "object_not_found",
+                  "message": "Database not found or not shared with integration."
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -418,6 +379,21 @@
           },
           "default": {
             "description": "Default response"
+          },
+          "404": {
+            "description": "Database not found or not queryable (inline?)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "object": "error",
+                  "code": "object_not_found",
+                  "message": "Database not found or not shared with integration."
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -465,6 +441,21 @@
           },
           "default": {
             "description": "Default response"
+          },
+          "404": {
+            "description": "Database not found or not queryable (inline?)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "object": "error",
+                  "code": "object_not_found",
+                  "message": "Database not found or not shared with integration."
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -488,7 +479,17 @@
           }
         ],
         "operationId": "queryDatabase",
-        "summary": "Query Database"
+        "summary": "Query Database",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatabaseQuery"
+              }
+            }
+          }
+        },
+        "description": "⚠️ Do **not** call this endpoint if the retrieved database's `is_inline` value is true."
       }
     },
     "/v1/file_uploads": {
@@ -1381,6 +1382,12 @@
           "properties": {
             "type": "object",
             "additionalProperties": true
+          },
+          "is_inline": {
+            "type": "boolean"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/Parent"
           }
         }
       },
@@ -1521,8 +1528,16 @@
               "type": "object",
               "additionalProperties": true
             }
+          },
+          "start_cursor": {
+            "type": "string"
+          },
+          "page_size": {
+            "type": "integer",
+            "maximum": 100
           }
-        }
+        },
+        "additionalProperties": false
       },
       "DatabaseRecord": {
         "type": "object",
@@ -1585,6 +1600,66 @@
           "result_data": {
             "type": "object",
             "additionalProperties": true
+          }
+        }
+      },
+      "Parent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "page_id"
+              },
+              "page_id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "page_id"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "workspace"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "description": "Parent object for databases (page or workspace)."
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "object",
+          "status",
+          "code",
+          "message"
+        ],
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "status": {
+            "type": "integer"
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
           }
         }
       }

--- a/public/notion-openapi.yaml
+++ b/public/notion-openapi.yaml
@@ -205,51 +205,27 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/DatabaseCreate'
-            examples:
-              basic:
-                value:
-                  properties:
-                    Name:
-                      type: title
-                      title: {}
-              create-activity-logs:
-                value:
-                  parent:
-                    type: page_id
-                    page_id: <PAGE_ID>
-                  title:
-                    - type: text
-                      text:
-                        content: Activity Logs
-                  properties:
-                    Name:
-                      type: title
-                      title: {}
-                    Action:
-                      type: select
-                      select:
-                        options: []
-                    Endpoint:
-                      type: multi_select
-                      multi_select:
-                        options: []
-                    Timestamp:
-                      type: date
-                      date: {}
-                    HTTP Status:
-                      type: number
-                      number: {}
       summary: Create Database
-  /v1/databases/{database_id}:
-    get:
-      responses:
-        '200':
-          description: OK
-        '400':
-          description: Bad request
-        default:
-          description: Default response
-      parameters:
+    /v1/databases/{database_id}:
+      get:
+        responses:
+          '200':
+            description: OK
+          '400':
+            description: Bad request
+          '404':
+            description: Database not found or not queryable (inline?)
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Error'
+                example:
+                  object: error
+                  code: object_not_found
+                  message: Database not found or not shared with integration.
+          default:
+            description: Default response
+        parameters:
         - name: Notion-Version
           in: header
           required: true
@@ -264,15 +240,25 @@ paths:
             type: string
       operationId: retrieveDatabase
       summary: Retrieve Database
-    patch:
-      responses:
-        '200':
-          description: OK
-        '400':
-          description: Bad request
-        default:
-          description: Default response
-      parameters:
+      patch:
+        responses:
+          '200':
+            description: OK
+          '400':
+            description: Bad request
+          '404':
+            description: Database not found or not queryable (inline?)
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Error'
+                example:
+                  object: error
+                  code: object_not_found
+                  message: Database not found or not shared with integration.
+          default:
+            description: Default response
+        parameters:
         - name: Notion-Version
           in: header
           required: true
@@ -295,11 +281,26 @@ paths:
       summary: Update Database
   /v1/databases/{database_id}/query:
     post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DatabaseQuery'
       responses:
         '200':
           description: OK
         '400':
           description: Bad request
+        '404':
+          description: Database not found or not queryable (inline?)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                object: error
+                code: object_not_found
+                message: Database not found or not shared with integration.
         default:
           description: Default response
       parameters:
@@ -317,6 +318,7 @@ paths:
             type: string
       operationId: queryDatabase
       summary: Query Database
+      description: "⚠️ Do **not** call this endpoint if the retrieved database's `is_inline` value is true."
   /v1/file_uploads:
     get:
       responses:
@@ -696,6 +698,10 @@ components:
         properties:
           type: object
           additionalProperties: true
+        is_inline:
+          type: boolean
+        parent:
+          $ref: '#/components/schemas/Parent'
     PageUpdate:
       type: object
       properties:
@@ -900,6 +906,31 @@ components:
         properties:
           type: object
           additionalProperties: true
+        is_inline:
+          type: boolean
+        parent:
+          $ref: '#/components/schemas/Parent'
+    Parent:
+      oneOf:
+        - type: object
+          properties:
+            type:
+              const: page_id
+            page_id:
+              type: string
+              format: uuid
+          required:
+            - type
+            - page_id
+          additionalProperties: false
+        - type: object
+          properties:
+            type:
+              const: workspace
+          required:
+            - type
+          additionalProperties: false
+      description: Parent object for databases (page or workspace).
     User:
       type: object
       required:
@@ -997,6 +1028,12 @@ components:
           items:
             type: object
             additionalProperties: true
+        start_cursor:
+          type: string
+        page_size:
+          type: integer
+          maximum: 100
+      additionalProperties: false
     DatabaseRecord:
       type: object
       required:
@@ -1013,6 +1050,9 @@ components:
         record_data:
           type: object
           additionalProperties: true
+    Parent:
+      oneOf:
+        - type: object
     SearchRequest:
       type: object
       properties:
@@ -1041,6 +1081,24 @@ components:
         result_data:
           type: object
           additionalProperties: true
+    Error:
+      type: object
+      required:
+        - object
+        - status
+        - code
+        - message
+      properties:
+        object:
+          type: string
+          enum:
+            - error
+        status:
+          type: integer
+        code:
+          type: string
+        message:
+          type: string
   securitySchemes:
     BearerAuth:
       type: http


### PR DESCRIPTION
## Summary
- extend Database schema with `is_inline` and `parent`
- define new `Parent` and `DatabaseQuery` components
- add Error object and remove outdated examples
- document optional request body for database query and warn about inline DBs
- include 404 responses across database operations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ae32dbb1c832793ab6b5ed1e3e703