### PR TITLE
Patch body params

### DIFF
--- a/weon.json
+++ b/weon.json
@@ -126,6 +126,7 @@
             "required": true,
             "schema": {
               "type": "object",
+              "properties": {},
               "additionalProperties": true
             }
           }
@@ -209,6 +210,7 @@
             "required": true,
             "schema": {
               "type": "object",
+              "properties": {},
               "additionalProperties": true
             }
           }
@@ -250,6 +252,7 @@
             "required": true,
             "schema": {
               "type": "object",
+              "properties": {},
               "additionalProperties": true
             }
           }
@@ -407,6 +410,7 @@
             "required": true,
             "schema": {
               "type": "object",
+              "properties": {},
               "additionalProperties": true
             }
           }
@@ -492,6 +496,7 @@
             "required": true,
             "schema": {
               "type": "object",
+              "properties": {},
               "additionalProperties": true
             }
           }
@@ -534,6 +539,7 @@
             "required": true,
             "schema": {
               "type": "object",
+              "properties": {},
               "additionalProperties": true
             }
           }
@@ -619,6 +625,7 @@
             "required": true,
             "schema": {
               "type": "object",
+              "properties": {},
               "additionalProperties": true
             }
           }
@@ -744,6 +751,7 @@
             "required": true,
             "schema": {
               "type": "object",
+              "properties": {},
               "additionalProperties": true
             }
           }


### PR DESCRIPTION
## Summary
- add empty `properties` object to all body parameters in `weon.json`

## Testing
- `node - <<'EOF'
const fs=require('fs');
const data=JSON.parse(fs.readFileSync('weon.json','utf8'));
let ids=[];let cnt=0;
for(const [path,methods] of Object.entries(data.paths))for(const [m,op] of Object.entries(methods)){if(op.parameters)for(const p of op.parameters){if(p.name==='body' && p.schema?.type==='object' && 'properties' in p.schema){cnt++;ids.push(op.operationId);}}}
console.log(cnt,ids)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685ce380263c8327bf681768c3b937d7